### PR TITLE
fix: asm! macro is not allowed in naked functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,10 @@ This release includes basical aclint functionalities.
 
 ### Fixed
 
+## [v0.1.1]
+
+### Fixed
+
+- replace `#[naked]` with `#[unsafe(naked)]` for stable Rust
+
 [v0.1.0]: https://github.com/rustsbi/aclint/releases/tag/v0.1.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 //!
 //! RISC-V ACLINT is defined in <https://github.com/riscv/riscv-aclint>.
 #![no_std]
-#![feature(naked_functions)]
 #![deny(warnings)]
 
 use core::{arch::naked_asm, cell::UnsafeCell};
@@ -85,7 +84,7 @@ impl SifiveClint {
 }
 
 impl SifiveClint {
-    #[naked]
+    #[unsafe(naked)]
     pub extern "C" fn read_mtime_naked(&self) -> u64 {
         unsafe {
             naked_asm!(
@@ -106,7 +105,7 @@ impl SifiveClint {
         }
     }
 
-    #[naked]
+    #[unsafe(naked)]
     pub extern "C" fn write_mtime_naked(&self, val: u64) -> u64 {
         unsafe {
             naked_asm!(
@@ -127,7 +126,7 @@ impl SifiveClint {
         }
     }
 
-    #[naked]
+    #[unsafe(naked)]
     pub extern "C" fn read_mtimecmp_naked(&self, hart_idx: usize) -> u64 {
         unsafe {
             naked_asm!(
@@ -145,7 +144,7 @@ impl SifiveClint {
         }
     }
 
-    #[naked]
+    #[unsafe(naked)]
     pub extern "C" fn write_mtimecmp_naked(&self, hart_idx: usize, val: u64) {
         unsafe {
             naked_asm!(
@@ -163,7 +162,7 @@ impl SifiveClint {
         }
     }
 
-    #[naked]
+    #[unsafe(naked)]
     pub extern "C" fn read_msip_naked(&self, hart_idx: usize) -> bool {
         unsafe {
             naked_asm!(
@@ -176,7 +175,7 @@ impl SifiveClint {
         }
     }
 
-    #[naked]
+    #[unsafe(naked)]
     pub extern "C" fn set_msip_naked(&self, hart_idx: usize) {
         unsafe {
             naked_asm!(
@@ -190,7 +189,7 @@ impl SifiveClint {
         }
     }
 
-    #[naked]
+    #[unsafe(naked)]
     pub extern "C" fn clear_msip_naked(&self, hart_idx: usize) {
         unsafe {
             naked_asm!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,120 +86,106 @@ impl SifiveClint {
 impl SifiveClint {
     #[unsafe(naked)]
     pub extern "C" fn read_mtime_naked(&self) -> u64 {
-        unsafe {
-            naked_asm!(
-                "   addi sp, sp, -8
-                    sd   a1, (sp)
+        naked_asm!(
+            "   addi sp, sp, -8
+                sd   a1, (sp)
 
-                    li   a1, {offset}
-                    add  a0, a0, a1
+                li   a1, {offset}
+                add  a0, a0, a1
 
-                    ld   a1, (sp)
-                    addi sp, sp,  8
+                ld   a1, (sp)
+                addi sp, sp,  8
 
-                    ld   a0, (a0)
-                    ret
-                ",
-                offset = const Self::MTIME_OFFSET,
-            )
-        }
+                ld   a0, (a0)
+                ret
+            ",
+            offset = const Self::MTIME_OFFSET,
+        )
     }
 
     #[unsafe(naked)]
     pub extern "C" fn write_mtime_naked(&self, val: u64) -> u64 {
-        unsafe {
-            naked_asm!(
-                "   addi sp, sp, -8
-                    sd   a1, (sp)
+        naked_asm!(
+            "   addi sp, sp, -8
+                sd   a1, (sp)
 
-                    li   a1, {offset}
-                    add  a0, a0, a1
+                li   a1, {offset}
+                add  a0, a0, a1
 
-                    ld   a1, (sp)
-                    addi sp, sp,  8
+                ld   a1, (sp)
+                addi sp, sp,  8
 
-                    sd   a1, (a0)
-                    ret
-                ",
-                offset = const Self::MTIME_OFFSET,
-            )
-        }
+                sd   a1, (a0)
+                ret
+            ",
+            offset = const Self::MTIME_OFFSET,
+        )
     }
 
     #[unsafe(naked)]
     pub extern "C" fn read_mtimecmp_naked(&self, hart_idx: usize) -> u64 {
-        unsafe {
-            naked_asm!(
-                "   slli a1, a1, 3
-                    add  a0, a0, a1
+        naked_asm!(
+            "   slli a1, a1, 3
+                add  a0, a0, a1
 
-                    li   a1, {offset}
-                    add  a0, a0, a1
+                li   a1, {offset}
+                add  a0, a0, a1
 
-                    ld   a0, (a0)
-                    ret
-                ",
-                offset = const Self::MTIMER_OFFSET,
-            )
-        }
+                ld   a0, (a0)
+                ret
+            ",
+            offset = const Self::MTIMER_OFFSET,
+        )
     }
 
     #[unsafe(naked)]
     pub extern "C" fn write_mtimecmp_naked(&self, hart_idx: usize, val: u64) {
-        unsafe {
-            naked_asm!(
-                "   slli a1, a1, 3
-                    add  a0, a0, a1
+        naked_asm!(
+            "   slli a1, a1, 3
+                add  a0, a0, a1
 
-                    li   a1, {offset}
-                    add  a0, a0, a1
+                li   a1, {offset}
+                add  a0, a0, a1
 
-                    sd   a2, (a0)
-                    ret
-                ",
-                offset = const Self::MTIMER_OFFSET,
-            )
-        }
+                sd   a2, (a0)
+                ret
+            ",
+            offset = const Self::MTIMER_OFFSET,
+        )
     }
 
     #[unsafe(naked)]
     pub extern "C" fn read_msip_naked(&self, hart_idx: usize) -> bool {
-        unsafe {
-            naked_asm!(
-                "   slli a1, a1, 2
-                    add  a0, a0, a1
-                    lw   a0, (a0)
-                    ret
-                ",
-            )
-        }
+        naked_asm!(
+            "   slli a1, a1, 2
+                add  a0, a0, a1
+                lw   a0, (a0)
+                ret
+            ",
+        )
     }
 
     #[unsafe(naked)]
     pub extern "C" fn set_msip_naked(&self, hart_idx: usize) {
-        unsafe {
-            naked_asm!(
-                "   slli a1, a1, 2
-                    add  a0, a0, a1
-                    addi a1, zero, 1
-                    sw   a1, (a0)
-                    ret
-                ",
-            )
-        }
+        naked_asm!(
+            "   slli a1, a1, 2
+                add  a0, a0, a1
+                addi a1, zero, 1
+                sw   a1, (a0)
+                ret
+            ",
+        )
     }
 
     #[unsafe(naked)]
     pub extern "C" fn clear_msip_naked(&self, hart_idx: usize) {
-        unsafe {
-            naked_asm!(
-                "   slli a1, a1, 2
-                    add  a0, a0, a1
-                    sw   zero, (a0)
-                    ret
-                ",
-            )
-        }
+        naked_asm!(
+            "   slli a1, a1, 2
+                add  a0, a0, a1
+                sw   zero, (a0)
+                ret
+            ",
+        )
     }
 }
 


### PR DESCRIPTION
After [https://github.com/rust-lang/rust/pull/128651](https://github.com/rust-lang/rust/pull/128651) merged in nightly toolchain, `asm!` macro is not allowed in naked functions.

So what we need to do is just fix that.

**Change**:

- replace `#[naked]` with `#[unsafe(naked)]` for stable Rust